### PR TITLE
fix: Improve the response when referrer is missing or is the self domain (resolves #24)

### DIFF
--- a/src/server/routes/sso.js
+++ b/src/server/routes/sso.js
@@ -72,13 +72,16 @@ router.get("/google", async function (req, res) {
         if (refererOrigin !== config.server.selfDomain) {
             await dbOps.trackstate(state, refererOrigin, refererUrl);
         }
-    }
 
-    // Redirects to Google's `/authorize` endpoint
-    googleSso.authorize(res, dbOps, googleSso.options, state).then(null, (error) => {
-        console.log(error);
-        res.status(403).json({"isError": true, "message": error.message});
-    });
+        // Redirects to Google's `/authorize` endpoint
+        googleSso.authorize(res, dbOps, googleSso.options, state).then(null, (error) => {
+            console.log(error);
+            res.status(403).json({"isError": true, "message": error.message});
+        });
+    } else {
+        res.status(403).json({"isError": true, "message": "Missing the referrer information"});
+        return;
+    }
 });
 
 /**
@@ -149,7 +152,8 @@ router.get("/google/login/callback", async function (req, res) {
             } else {
                 // This is a sign on process instantiated on the Personal Data Server website.
                 // Return the access token from Google.
-                res.json({"accessToken": JSON.stringify(accessTokenRecord.access_token, null, 2)});
+                console.debug("Google sign in successfully. Access token: " + accessTokenRecord.access_token);
+                res.json({"message": "Google sign in successfully."});
             }
         }).catch((error) => {
             res.status(403).json({"isError": true, "message": error.message});

--- a/tests/googleSsoTests.js
+++ b/tests/googleSsoTests.js
@@ -133,7 +133,7 @@ jqUnit.test("Google SSO unit tests", async function () {
 });
 
 jqUnit.test("Google SSO integration tests", async function () {
-    jqUnit.expect(skipDocker ? 34 : 36);
+    jqUnit.expect(skipDocker ? 30 : 32);
     let serverStatus, response;
 
     if (!skipDocker) {
@@ -173,21 +173,13 @@ jqUnit.test("Google SSO integration tests", async function () {
     // Test the successful workflows of "/sso/google" & "/sso/google/login/callback"
     // Success case 1: referer is not in the "/sso/google" request header
     response = await fluid.tests.utils.sendRequest(serverUrl, "/sso/google");
-    fluid.tests.utils.testResponse(response, 200, "", "/sso/google");
+    fluid.tests.utils.testResponse(response, 403, {
+        isError: true,
+        message: "Missing the referrer information"
+    }, "/sso/google");
     fluid.tests.googleSso.testNumOfRecords(
         "When the referer is not in the request header, referer_tracker table is not upated",
         dbOps, "referer_tracker", 0
-    );
-
-    response = await fluid.tests.utils.sendRequest(serverUrl, "/sso/google/login/callback?code=" + fluid.tests.utils.mockAuthCode + "&state=" + fluid.tests.utils.authPayload.state);
-    fluid.tests.utils.testResponse(response, 200, {accessToken: "\"PatAccessToken.someRandomeString\""}, "/sso/google/login/callback");
-    fluid.tests.googleSso.testNumOfRecords(
-        "When the referer is not in the request header, access token is generated",
-        dbOps, "access_token", 1
-    );
-    fluid.tests.googleSso.testNumOfRecords(
-        "When the referer is not in the request header, login token is not generated",
-        dbOps, "login_token", 0
     );
 
     // Success case 2: referer is Personal Data Server self domain
@@ -203,7 +195,7 @@ jqUnit.test("Google SSO integration tests", async function () {
     );
 
     response = await fluid.tests.utils.sendRequest(serverUrl, "/sso/google/login/callback?code=" + fluid.tests.utils.mockAuthCode + "&state=" + fluid.tests.utils.authPayload.state);
-    fluid.tests.utils.testResponse(response, 200, {accessToken: "\"PatAccessToken.someRandomeString\""}, "/sso/google/login/callback");
+    fluid.tests.utils.testResponse(response, 200, {"message": "Google sign in successfully."}, "/sso/google/login/callback");
     fluid.tests.googleSso.testNumOfRecords(
         "When the referer is Personal Data Server self domain, access token is generated",
         dbOps, "access_token", 1


### PR DESCRIPTION
Resolves https://github.com/fluid-project/personal-data-server/issues/24.

This pull request includes two changes:

1. When a referrer url is not provided, respond with an error message "Missing the referrer information".
2. When the referrer is the domain of Personal Data Server, complete the Google sign on process, respond with a success message "Google sign in successfully". The google assigned access token will be output in the server log.