### PR TITLE
[INFRA-266] Force Docker image rebuild in deploy-main workflow

### DIFF
--- a/scripts/gha-deploy-main.sh
+++ b/scripts/gha-deploy-main.sh
@@ -10,4 +10,4 @@ export PDS_SERVERPORT=38095
 export PDS_DOMAIN=https://pds.fluidproject.org
 
 cd /srv/fluid-pds-main
-/usr/local/bin/docker-compose up -d --force-recreate
+/usr/local/bin/docker-compose up -d --build --force-recreate


### PR DESCRIPTION
`docker-compose up` was not rebuilding the Docker image which was causing code changes to not reflect in the running container.